### PR TITLE
Report link refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,23 +105,23 @@ jobs:
 
       - name: Prepare gh-pages environment
         run: |
-          rm -rf gh-pages/reports
-          mkdir gh-pages/reports -p
+          rm -rf gh-pages/docs
+          mkdir gh-pages/docs -p
 
       - name: Generate PPS report HTML
         uses: docker://pandoc/latex:2.11.4
         with:
-          args: -d ./pandoc/pps-report/html.yaml -o ./gh-pages/reports/pps.html
+          args: -d ./pandoc/pps-report/html.yaml -o ./gh-pages/docs/pps-report.html
 
       - name: Generate LSS report HTML
         uses: docker://pandoc/latex:2.11.4
         with:
-          args: -d ./pandoc/lss-report/html.yaml -o ./gh-pages/reports/lss.html
+          args: -d ./pandoc/lss-report/html.yaml -o ./gh-pages/docs/lss-report.html
 
       - name: Generate Appendix documents HTML
         uses: docker://pandoc/latex:2.11.4
         with:
-          args: -d ./pandoc/appendix/html.yaml -o ./gh-pages/reports/appendix.html
+          args: -d ./pandoc/appendix/html.yaml -o ./gh-pages/docs/appendix.html
 
       - name: Push reports to gh-pages
         run: |

--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@
 This is the entry point for PPS and LSS reports. We decided to set them in a
 separate repository, as the structure of them begun to rise in complexity.
 
-## How to consult reports?
+The documentation is written in Markdown, available in the `src` directory. Anyway, more convenient consultation formats 
+are provided: for
+each release, PDF LaTeX and web version are generated automatically, using [Pandoc](https://pandoc.org/index.html).
 
-You can examine the reports from the
-[PPS report website](https://scalaquest.github.io/Reports/reports/pps.html),
-[LSS report website](https://scalaquest.github.io/Reports/reports/lss.html), in
-[LaTeX PDF](https://github.com/scalaquest/Reports/releases/latest) format, or
-directly from the
-[Markdown files](https://github.com/scalaquest/Reports/tree/main/src/markdown).
+## How to consult the documentation?
+
+You can examine the web version of reports and the appendix document from the
+[PPS report website](https://scalaquest.github.io/Reports/docs/pps-report.html),
+[LSS report website](https://scalaquest.github.io/Reports/docs/lss-report.html) and
+[appendix website](https://scalaquest.github.io/Reports/docs/appendix.html).
+
+If you prefer a LaTex PDF version, you can download the latest release 
+[from here](https://github.com/scalaquest/Reports/releases/latest).

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ You can examine the web version of reports and the appendix document from the
 [LSS report website](https://scalaquest.github.io/Reports/docs/lss-report.html) and
 [appendix website](https://scalaquest.github.io/Reports/docs/appendix.html).
 
-If you prefer a LaTex PDF version, you can download the latest release 
+If you prefer a LaTeX PDF version, you can download the latest release 
 [from here](https://github.com/scalaquest/Reports/releases/latest).


### PR DESCRIPTION
Update release workflow in order to put generated web version into the `docs` directory of the gh-pages space. Updated readme links accordingly.